### PR TITLE
Get apple sdk root and deployment target from cc instead of xcrun

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ rust-version = "1.63"
 
 [dependencies]
 jobserver = { version = "0.1.30", default-features = false, optional = true }
+serde_json = "1"
 shlex = "1.3.0"
 
 [target.'cfg(unix)'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3900,8 +3900,8 @@ impl Build {
 
     // Gets the sysroot from cc by looking for the -sysroot flag. Used b/c the SYSROOT environment 
     // variable is not set when running using hermetic bazel.
-    fn sysroot_from_cc() -> Option<String> {
-        let cc: String = env::var("CC").ok()?;
+    fn sysroot_from_cc(&self) -> Option<String> {
+        let cc = self.getenv_unwrap_str("CC").ok()?;
         let out = Command::new(cc)
             .args(["-v", "-E", "-"])
             .stdin(std::process::Stdio::null())
@@ -3920,8 +3920,8 @@ impl Build {
 
     // First gets the sysroot from cc, then looks for the SDKSettings.json file in the sysroot and
     // returns the "Version" field.
-    fn deployment_target_from_cc() -> Option<String> {
-        if let Some(sysroot) = Self::sysroot_from_cc() {
+    fn deployment_target_from_cc(&self) -> Option<String> {
+        if let Some(sysroot) = self.sysroot_from_cc() {
             let sdk_settings_path = Path::new(&sysroot).join("SDKSettings.json");
             let sdk_settings = std::fs::read_to_string(sdk_settings_path).ok()?;
             let sdk_settings: serde_json::Value = serde_json::from_str(&sdk_settings).ok()?;
@@ -3935,7 +3935,7 @@ impl Build {
         // do not have xcrun available in the xcode toolchain (it's an OSX host library). So running
         // it will use non-hermetic xcode toolchain and fail on CI machines where it is not 
         // installed (and give incorrect paths even if it is installed).
-        if let Some(sysroot) = Self::sysroot_from_cc() {
+        if let Some(sysroot) = self.sysroot_from_cc() {
             return Ok(Arc::from(OsStr::new(&sysroot)));
         }
 
@@ -4026,11 +4026,13 @@ impl Build {
             return ret;
         }
 
-        // NOTE(paris): Use an environment variable here because when running using hermetic bazel 
-        // we do not have xcrun available in the xcode toolchain (it's an OSX host library). So we
-        // avoid calling it here by setting environment variables instead.
         let default_deployment_from_sdk = || -> Option<Arc<str>> {
-            if let Some(version) = Self::deployment_target_from_cc() {
+            // NOTE(paris): Fetch the deployment target directly from cc because when running using 
+            // hermetic bazel, we do not have xcrun available in the xcode toolchain (it's an OSX 
+            // host library). So running it will use non-hermetic xcode toolchain and fail on CI 
+            // machines where it is not installed (and give incorrect paths even if it is 
+            // installed).
+            if let Some(version) = self.deployment_target_from_cc() {
                 Some(Arc::from(version))
             } else {
                 let version = run_output(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3902,7 +3902,6 @@ impl Build {
     // variable is not set when running using hermetic bazel.
     fn sysroot_from_cc() -> Option<String> {
         let cc: String = env::var("CC").ok()?;
-        println!("cargo:warning=cc: [lib@apple_sdk_root_inner]: cc: {}", cc);
         let out = Command::new(cc)
             .args(["-v", "-E", "-"])
             .stdin(std::process::Stdio::null())
@@ -3937,7 +3936,6 @@ impl Build {
         // it will use non-hermetic xcode toolchain and fail on CI machines where it is not 
         // installed (and give incorrect paths even if it is installed).
         if let Some(sysroot) = Self::sysroot_from_cc() {
-            println!("cargo:warning=cc: [lib@apple_sdk_root_inner]: Returning early with sysroot from CC: {}", &sysroot);
             return Ok(Arc::from(OsStr::new(&sysroot)));
         }
 
@@ -4031,13 +4029,10 @@ impl Build {
         // NOTE(paris): Use an environment variable here because when running using hermetic bazel 
         // we do not have xcrun available in the xcode toolchain (it's an OSX host library). So we
         // avoid calling it here by setting environment variables instead.
-        println!("cargo:warning=cc: [lib@apple_deployment_target]: sdk: {}", sdk);
         let default_deployment_from_sdk = || -> Option<Arc<str>> {
             if let Some(version) = Self::deployment_target_from_cc() {
-                println!("cargo:warning=cc: [lib@apple_deployment_target]: Using deplolyment target version from CC: {}", version);
-                return Some(Arc::from(version));
+                Some(Arc::from(version))
             } else {
-                println!("cargo:warning=cc: [lib@apple_deployment_target]: no version found");
                 let version = run_output(
                     self.cmd("xcrun")
                         .arg("--show-sdk-version")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3898,7 +3898,7 @@ impl Build {
         Ok(())
     }
 
-    // Gets the sysroot from cc by looking for the -sysroot flag. Used b/c neither SDKROOT nor 
+    // Gets the sysroot from cc by looking for the -sysroot flag. Used b/c neither SDKROOT nor
     // SYSROOT environment variables are set when running using hermetic bazel.
     fn sysroot_from_cc(&self) -> Option<String> {
         let cc = self.getenv_unwrap_str("CC").ok()?;
@@ -3906,7 +3906,8 @@ impl Build {
         let out = Command::new(cc)
             .args(["-v", "-E", "-"])
             .stdin(std::process::Stdio::null())
-            .output().ok()?;
+            .output()
+            .ok()?;
         let s = std::str::from_utf8(&out.stderr).ok()?;
         let mut it = s.split_whitespace();
         while let Some(t) = it.next() {
@@ -3934,7 +3935,7 @@ impl Build {
     fn apple_sdk_root_inner(&self, sdk: &str) -> Result<Arc<OsStr>, Error> {
         // NOTE(paris): Fetch the SDK directly from cc because when running using hermetic bazel, we
         // do not have xcrun available in the xcode toolchain (it's an OSX host library). So running
-        // it will use non-hermetic xcode toolchain and fail on CI machines where it is not 
+        // it will use non-hermetic xcode toolchain and fail on CI machines where it is not
         // installed (and give incorrect paths even if it is installed).
         if let Some(sysroot) = self.sysroot_from_cc() {
             return Ok(Arc::from(OsStr::new(&sysroot)));
@@ -4028,10 +4029,10 @@ impl Build {
         }
 
         let default_deployment_from_sdk = || -> Option<Arc<str>> {
-            // NOTE(paris): Fetch the deployment target directly from cc because when running using 
-            // hermetic bazel, we do not have xcrun available in the xcode toolchain (it's an OSX 
-            // host library). So running it will use non-hermetic xcode toolchain and fail on CI 
-            // machines where it is not installed (and give incorrect paths even if it is 
+            // NOTE(paris): Fetch the deployment target directly from cc because when running using
+            // hermetic bazel, we do not have xcrun available in the xcode toolchain (it's an OSX
+            // host library). So running it will use non-hermetic xcode toolchain and fail on CI
+            // machines where it is not installed (and give incorrect paths even if it is
             // installed).
             if let Some(version) = self.deployment_target_from_cc() {
                 Some(Arc::from(version))
@@ -4042,8 +4043,9 @@ impl Build {
                         .arg("--sdk")
                         .arg(sdk),
                     &self.cargo_output,
-                ).ok()?;
-        
+                )
+                .ok()?;
+
                 Some(Arc::from(std::str::from_utf8(&version).ok()?.trim()))
             }
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3898,10 +3898,11 @@ impl Build {
         Ok(())
     }
 
-    // Gets the sysroot from cc by looking for the -sysroot flag. Used b/c the SYSROOT environment 
-    // variable is not set when running using hermetic bazel.
+    // Gets the sysroot from cc by looking for the -sysroot flag. Used b/c neither SDKROOT nor 
+    // SYSROOT environment variables are set when running using hermetic bazel.
     fn sysroot_from_cc(&self) -> Option<String> {
         let cc = self.getenv_unwrap_str("CC").ok()?;
+        println!("cargo:warning=cc: [lib@sysroot_from_cc]: cc: {cc}");
         let out = Command::new(cc)
             .args(["-v", "-E", "-"])
             .stdin(std::process::Stdio::null())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3898,7 +3898,49 @@ impl Build {
         Ok(())
     }
 
+    // Gets the sysroot from cc by looking for the -sysroot flag. Used b/c the SYSROOT environment 
+    // variable is not set when running using hermetic bazel.
+    fn sysroot_from_cc() -> Option<String> {
+        let cc: String = env::var("CC").ok()?;
+        println!("cargo:warning=cc: [lib@apple_sdk_root_inner]: cc: {}", cc);
+        let out = Command::new(cc)
+            .args(["-v", "-E", "-"])
+            .stdin(std::process::Stdio::null())
+            .output().ok()?;
+        let s = std::str::from_utf8(&out.stderr).ok()?;
+        let mut it = s.split_whitespace();
+        while let Some(t) = it.next() {
+            if t == "-isysroot" {
+                if let Some(p) = it.next() {
+                    return Some(p.to_string());
+                }
+            }
+        }
+        None
+    }
+
+    // First gets the sysroot from cc, then looks for the SDKSettings.json file in the sysroot and
+    // returns the "Version" field.
+    fn deployment_target_from_cc() -> Option<String> {
+        if let Some(sysroot) = Self::sysroot_from_cc() {
+            let sdk_settings_path = Path::new(&sysroot).join("SDKSettings.json");
+            let sdk_settings = std::fs::read_to_string(sdk_settings_path).ok()?;
+            let sdk_settings: serde_json::Value = serde_json::from_str(&sdk_settings).ok()?;
+            return Some(sdk_settings["Version"].to_string());
+        }
+        None
+    }
+
     fn apple_sdk_root_inner(&self, sdk: &str) -> Result<Arc<OsStr>, Error> {
+        // NOTE(paris): Fetch the SDK directly from cc because when running using hermetic bazel, we
+        // do not have xcrun available in the xcode toolchain (it's an OSX host library). So running
+        // it will use non-hermetic xcode toolchain and fail on CI machines where it is not 
+        // installed (and give incorrect paths even if it is installed).
+        if let Some(sysroot) = Self::sysroot_from_cc() {
+            println!("cargo:warning=cc: [lib@apple_sdk_root_inner]: Returning early with sysroot from CC: {}", &sysroot);
+            return Ok(Arc::from(OsStr::new(&sysroot)));
+        }
+
         // Code copied from rustc's compiler/rustc_codegen_ssa/src/back/link.rs.
         if let Some(sdkroot) = self.getenv("SDKROOT") {
             let p = Path::new(&sdkroot);
@@ -3986,17 +4028,26 @@ impl Build {
             return ret;
         }
 
+        // NOTE(paris): Use an environment variable here because when running using hermetic bazel 
+        // we do not have xcrun available in the xcode toolchain (it's an OSX host library). So we
+        // avoid calling it here by setting environment variables instead.
+        println!("cargo:warning=cc: [lib@apple_deployment_target]: sdk: {}", sdk);
         let default_deployment_from_sdk = || -> Option<Arc<str>> {
-            let version = run_output(
-                self.cmd("xcrun")
-                    .arg("--show-sdk-version")
-                    .arg("--sdk")
-                    .arg(sdk),
-                &self.cargo_output,
-            )
-            .ok()?;
-
-            Some(Arc::from(std::str::from_utf8(&version).ok()?.trim()))
+            if let Some(version) = Self::deployment_target_from_cc() {
+                println!("cargo:warning=cc: [lib@apple_deployment_target]: Using deplolyment target version from CC: {}", version);
+                return Some(Arc::from(version));
+            } else {
+                println!("cargo:warning=cc: [lib@apple_deployment_target]: no version found");
+                let version = run_output(
+                    self.cmd("xcrun")
+                        .arg("--show-sdk-version")
+                        .arg("--sdk")
+                        .arg(sdk),
+                    &self.cargo_output,
+                ).ok()?;
+        
+                Some(Arc::from(std::str::from_utf8(&version).ok()?.trim()))
+            }
         };
 
         let deployment_from_env = |name: &str| -> Option<Arc<str>> {


### PR DESCRIPTION
### What
As part of Tauri building via Bazel, this PR fixes a hermeticity bug coming from `objc2-exception-helper` using `cc-rs` (the crate is just called `cc` though). 

Specifically, `cc-rs` previously used the host machine's `xcrun` to fetch the Apple SDKs and deployment targets for iOS and OSX. The issue is that `xcrun` is a host-machine binary which points `cc-rs` at non-hermetic XCode SDKs. This results in non-hermetic builds locally (when XCode and XCode CLI Tools have been downloaded) and failing builds on CI (when they are not present). The error you get on CI is:
```
11:12:47 cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
11:12:47 cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
11:12:47 CRATE_CC_NO_DEFAULTS = None
11:12:47 DEBUG = Some(true)
11:12:47 cargo:rerun-if-env-changed=IPHONEOS_DEPLOYMENT_TARGET
11:12:47 IPHONEOS_DEPLOYMENT_TARGET = None
11:12:47 cargo:warning=xcrun: error: SDK "iphoneos" cannot be located
11:12:47 cargo:warning=xcrun: error: SDK "iphoneos" cannot be located
11:12:47 cargo:warning=xcrun: error: unable to lookup item 'SDKVersion' in SDK 'iphoneos'
11:12:47 Detecting "ios" SDK path for iphoneos
11:12:47 cargo:rerun-if-env-changed=SDKROOT
11:12:47 SDKROOT = None
11:12:47 cargo:warning=xcrun: error: SDK "iphoneos" cannot be located
11:12:47 cargo:warning=xcrun: error: SDK "iphoneos" cannot be located
11:12:47 cargo:warning=xcrun: error: unable to lookup item 'Path' in SDK 'iphoneos'
11:12:47 
11:12:47 --stderr:
11:12:47 
11:12:47 
11:12:47 error occurred in cc-rs: command did not execute successfully (status code exit status: 1): "xcrun" "--show-sdk-path" "--sdk" "iphoneos"
```

Our solution here is to use `cc`  to find the SDK path and deployment target. Feels like somewhat of a hack, but appears to work and the code is simple enough.

### Testing
I can build and run Doty run with this plus the new `rust_binary()` target.